### PR TITLE
Compatibility with Django >= 1.4

### DIFF
--- a/spawning/django_factory.py
+++ b/spawning/django_factory.py
@@ -24,7 +24,6 @@
 import inspect
 import os
 import django.core.handlers.wsgi
-from django.core.servers.basehttp import AdminMediaHandler
 
 import spawning.util
 
@@ -52,7 +51,6 @@ def app_factory(config):
     os.environ['DJANGO_SETTINGS_MODULE'] = config['django_settings_module']
 
     app = django.core.handlers.wsgi.WSGIHandler()
-    if config.get('dev'):
-        app = AdminMediaHandler(app)
+
     return app
 


### PR DESCRIPTION
In Django1.4 AdminMediaHandler requires that the project's settings are already loaded when importing it.

Instead of deferring the loading of this class when needed in dev mode, I have deleted it because this class will be removed in Django 1.5.

https://docs.djangoproject.com/en/dev/internals/deprecation/#id2
https://code.djangoproject.com/ticket/18035

I hope that you could make a new release integrating this patch.

Regards
